### PR TITLE
Fix #5 - use Average framerate instead of Framerate. Thanks to @hamelg.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,12 @@
 {
   "ruff.nativeServer": "on",
   "[python]": {
-    "editor.formatOnSave": true,
     "editor.defaultFormatter": "charliermarsh.ruff"
   },
   "python.experiments.enabled": false,
   "ruff.configuration": "pyproject.toml",
+  "ruff.format": true,
+  "ruff.formatOnSave": true,
   "python.terminal.shellIntegration.enabled": true,
   "debugpy.debugJustMyCode": false
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+mythcommflagwrapper (0.1.3ubuntu1) noble; urgency=medium
+
+  * Fix issue 5: Use Average framerate instead of Frame Rate to address
+    https://github.com/charrus/mythcommflag/issues/5 - thanks to @hamelg.
+
+  * Bump version.
+
+ -- Charlie Rusbridger <charlie@rusbridger.com>  Tue, 25 Mar 2025 11:20:33 +0000
+
 mythcommflagwrapper (0.1.2ubuntu1) noble; urgency=medium
 
   * Include cli

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mythcommflagwrapper (0.1.3ubuntu2) noble; urgency=medium
+
+  * Fix missing _parse_edl_file.
+
+ -- Charlie Rusbridger <charlie@rusbridger.com>  Tue, 25 Mar 2025 13:40:18 +0000
+
 mythcommflagwrapper (0.1.3ubuntu1) noble; urgency=medium
 
   * Fix issue 5: Use Average framerate instead of Frame Rate to address

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/charrus/mythcommflag"
 packages = [
     { include = "mythcommflagwrapper", from = "src" }
 ]
-version = "0.1.2"
+version = "0.1.3"
 
 [project.urls]
 Repository = "https://github.com/charrus/mythcommflag"
@@ -24,7 +24,7 @@ mythcommflag-wrapper = "mythcommflagwrapper.scripts.mythcommflag-wrapper:main"
 name = "mythcommflagwrapper"
 description = "Wrapper around comskip for use by MythTV"
 authors = ["Charlie Rusbridger <charlie@rusbridger.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = "^3.12"

--- a/src/mythcommflagwrapper/__main__.py
+++ b/src/mythcommflagwrapper/__main__.py
@@ -179,9 +179,10 @@ class BaseRecording:
             return fps
         raise ComskipError("Could not determine FPS from comskip output")
 
-    def _parse_edl_file(self, edl_file: Path) -> List[str]:
+    def _parse_edl_file(self, comskipdir: Path) -> List[str]:
         """Parse EDL file and return skiplist."""
         skiplist: List[str] = []
+        edl_file = Path(comskipdir) / Path(self._filename.name).with_suffix(".edl")
 
         #
         # EDL format:

--- a/src/mythcommflagwrapper/__main__.py
+++ b/src/mythcommflagwrapper/__main__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8-unix -*-
 
 """Wrapper around comskip for use by MythTV."""
 
@@ -184,7 +184,7 @@ class BaseRecording:
         # 1640.04 1891.80 3
         # 2546.64 2798.80 3
 
-        fps_re = re.compile(r"(?s).*Frame Rate set to ([^ ]+) f/s.*")
+        fps_re = re.compile(r"(?s).*Average framerate:\s+(\S+)")
         if m := fps_re.match(stdout):
             fps = float(m.group(1))
             logger.info("fps: %f", fps)


### PR DESCRIPTION
```
Input #0, mpegts, from '/mythtv-sg/default/20001_20250322200500.ts':
  Duration: 03:04:57.92, start: 56789.476211, bitrate: 5969 kb/s
  Program 1 
  Stream #0:0[0x78]: Video: h264 (High) ([27][0][0][0] / 0x001B), yuv420p(tv, bt709, top first), 1920x1080 [SAR 1:1 DAR 16:9], 25 fps, 50 tbr, 90k tbn
  Stream #0:1[0x82](fra): Audio: eac3 ([135][0][0][0] / 0x0087), 48000 Hz, stereo, fltp, 128 kb/s
  Stream #0:2[0x83](qaa): Audio: eac3 ([135][0][0][0] / 0x0087), 48000 Hz, stereo, fltp, 128 kb/s
  Stream #0:3[0x84](fra): Audio: eac3 ([135][0][0][0] / 0x0087), 48000 Hz, stereo, fltp, 96 kb/s (visual impaired) (descrip>
  Stream #0:4[0x96](fra): Subtitle: dvb_subtitle (dvbsub) ([6][0][0][0] / 0x0006) (hearing impaired)
  Stream #0:5[0x97](fra): Subtitle: dvb_subtitle (dvbsub) ([6][0][0][0] / 0x0006)
[h264 @ 0x5597bdc98ec0] gray decoding requested but not enabled at configuration time
Frame Rate set to 50.000 f/s
...
Finished scanning file.  Starting to build Commercial List.
WARNING: Actual framerate (25.000) different from specified framerate (50.000)
Internal frame numbers will be different from .txt frame numbers
WARNING: Complex timeline or errors in the recording!!!!
Results may be wrong, .ref input will be misaligned. .txt editing will produce wrong results
...
Score threshold:            1.0500
Framerate:                  50.000
Average framerate:          25.000
Total commercial length:    0:32:12.87
```